### PR TITLE
GPII-434: Updates Infusion dependency to latest head revision.

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "author": "Fluid Project",
     "homepage": "http://www.fluidproject.org/",
     "dependencies": {
-        "infusion": "git://github.com/fluid-project/infusion.git#d5b2409f435f1c2a79914748b956891dcb065f94"
+        "infusion": "git://github.com/fluid-project/infusion.git#df5f8cfabf815a4086b778e73125c3c952dda4ec"
     },
     "devDependencies": {
         "grunt-shell": "0.6.4",


### PR DESCRIPTION
@amb26 This updates node-jqUnit to match the same version of Infusion (latest head revision) as used by Kettle, which I updated prior to merging in your GPII-434 pull request.

We will still need to bump Kettle's dependency on node-jqUnit to the latest head revision of the project repository once this gets merged in. Do we have a policy for how to merge these kinds of minor dependency revision changes? It's currently a bit awkward, but perhaps I'm not clear how we usually work in this regard.
